### PR TITLE
Resolve promise to avoid hang when handling files

### DIFF
--- a/packages/adapter-virtual/src/Resource.ts
+++ b/packages/adapter-virtual/src/Resource.ts
@@ -560,15 +560,15 @@ export default class Resource implements ResourceInterface {
 
       const mediaType = mime.getType(this.file.name);
       if (!mediaType) {
-        return 'application/octet-stream';
+        resolve('application/octet-stream');
       } else if (Array.isArray(mediaType)) {
-        return typeof mediaType[0] === 'string'
+        resolve(typeof mediaType[0] === 'string'
           ? mediaType[0]
-          : 'application/octet-stream';
+          : 'application/octet-stream');
       } else if (typeof mediaType === 'string') {
-        return mediaType;
+        resolve(mediaType);
       } else {
-        return 'application/octet-stream';
+        resolve('application/octet-stream');
       }
     });
   }


### PR DESCRIPTION
Returning inside a Promise does not resolve said Promise. The calling code will hang forever. This can easily be demostrated by using die virtual adapter with diretories and with and without a file entry. As soon as there is a file entry, it hangs. Resolving the promise solves this bug.